### PR TITLE
Chrome API update + infinite loop fix.

### DIFF
--- a/javascripts/background.js
+++ b/javascripts/background.js
@@ -126,7 +126,7 @@ var takeScreenshot = {
 
 					image.src = dataURI;
 				} else {
-                    chrome.tabs.sendMessage(self.tabId, {
+					chrome.tabs.sendMessage(self.tabId, {
 						"msg": "showError",
 						"originalParams": self.originalParams
 					});

--- a/javascripts/background.js
+++ b/javascripts/background.js
@@ -59,13 +59,13 @@ var takeScreenshot = {
 		chrome.browserAction.onClicked.addListener(function (tab) {
 			this.tabId = tab.id;
 
-			chrome.tabs.sendRequest(tab.id, {
+			chrome.tabs.sendMessage(tab.id, {
 				"msg": "getPageDetails"
 			});
 		}.bind(this));
 
 		// handle chrome requests
-		chrome.extension.onRequest.addListener(function (request, sender, callback) {
+		chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 			if (request.msg === "setPageDetails") {
 				this.size = request.size;
 				this.scrollBy = request.scrollBy;
@@ -87,7 +87,7 @@ var takeScreenshot = {
 	 * @param {Number} position
 	 */
 	scrollTo: function (position) {
-		chrome.tabs.sendRequest(this.tabId, {
+		chrome.tabs.sendMessage(this.tabId, {
 			"msg": "scrollPage",
 			"size": this.size,
 			"scrollBy": this.scrollBy,
@@ -126,7 +126,7 @@ var takeScreenshot = {
 
 					image.src = dataURI;
 				} else {
-					chrome.tabs.sendRequest(self.tabId, {
+                    chrome.tabs.sendMessage(self.tabId, {
 						"msg": "showError",
 						"originalParams": self.originalParams
 					});
@@ -139,7 +139,7 @@ var takeScreenshot = {
 	 * @description Send request to set original params of page
 	 */
 	resetPage: function () {
-		chrome.tabs.sendRequest(this.tabId, {
+		chrome.tabs.sendMessage(this.tabId, {
 			"msg": "resetPage",
 			"originalParams": this.originalParams
 		});

--- a/javascripts/content-script.js
+++ b/javascripts/content-script.js
@@ -3,7 +3,7 @@ function resetPage(originalParams) {
 	document.querySelector("html").style.overflow = originalParams.overflow;
 }
 
-chrome.extension.onRequest.addListener(function (request, sender, callback) {
+chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 	switch (request.msg) {
 		case "getPageDetails":
 			var size = {
@@ -23,7 +23,7 @@ chrome.extension.onRequest.addListener(function (request, sender, callback) {
 				)
 			};
 
-			chrome.extension.sendRequest({
+			chrome.extension.sendMessage({
 				"msg": "setPageDetails",
 				"size": size,
 				"scrollBy": window.innerHeight,
@@ -45,12 +45,12 @@ chrome.extension.onRequest.addListener(function (request, sender, callback) {
 			}
 
 			// last scrolling
-			if (request.size.height <= document.documentElement.scrollTop + request.scrollBy) {
+			if (request.size.height <= window.scrollY + request.scrollBy) {
 				lastCapture = true;
 				request.scrollTo = request.size.height - request.scrollBy;
 			}
 
-			chrome.extension.sendRequest({
+			chrome.extension.sendMessage({
 				"msg": "capturePage",
 				"position": request.scrollTo,
 				"lastCapture": lastCapture

--- a/javascripts/content-script.js
+++ b/javascripts/content-script.js
@@ -1,6 +1,6 @@
 function resetPage(originalParams) {
 	window.scrollTo(0, originalParams.scrollTop);
-	document.querySelector("html").style.overflow = originalParams.overflow;
+	document.querySelector("body").style.overflow = originalParams.overflow;
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, callback) {
@@ -28,7 +28,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 				"size": size,
 				"scrollBy": window.innerHeight,
 				"originalParams": {
-					"overflow": document.querySelector("html").style.overflow,
+					"overflow": document.querySelector("body").style.overflow,
 					"scrollTop": document.documentElement.scrollTop
 				}
 			});
@@ -41,7 +41,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 
 			// first scrolling
 			if (request.scrollTo === 0) {
-				document.querySelector("html").style.overflow = "hidden";
+				document.querySelector("body").style.overflow = "hidden";
 			}
 
 			// last scrolling

--- a/manifest.json
+++ b/manifest.json
@@ -16,14 +16,13 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["http://*/*", "https://*/*"],
+			"matches": ["<all_urls>"],
 			"js": ["javascripts/content-script.js"]
 		}
 	],
 	"permissions": [
-		"tabs",
-		"http://*/",
-		"https://*/"
+        "activeTab",
+		"tabs"
 	],
 	"browser_action": {
 		"default_icon": {


### PR DESCRIPTION
Comments from users in #1 and #2 were caused by outdated api as well as infinite loop by using undefined porpert:  document.documentElement.scrollTop - replaced with window.scrollY works like charm!
