### PR TITLE
Workaround for scroll-behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Chrome extension to take screenshot of the entire web page
 
 ##Usage
 - Go to any web page
-- By default, plugin will hide DOM elements with `display=fixed` and will scroll through whole page once before taking the screenshot. You can control that by right-clicking the plugin icon ![plugin icon](https://raw2.github.com/marcinwieprzkowicz/take-screenshot/master/images/icon-19.png)
+- By default, plugin will hide DOM elements with `display=fixed` or `display=sticky` and will scroll through whole page once before taking the screenshot. You can control that by right-clicking the plugin icon ![plugin icon](https://raw2.github.com/marcinwieprzkowicz/take-screenshot/master/images/icon-19.png)
 - Click on plugin icon ![plugin icon](https://raw2.github.com/marcinwieprzkowicz/take-screenshot/master/images/icon-19.png)
 - Wait, until new tab will open with image

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Chrome extension to take screenshot of the entire web page
 
 ##Usage
 - Go to any web page
+- By default, plugin will hide DOM elements with `display=fixed` and will scroll through whole page once before taking the screenshot. You can control that by right-clicking the plugin icon ![plugin icon](https://raw2.github.com/marcinwieprzkowicz/take-screenshot/master/images/icon-19.png)
 - Click on plugin icon ![plugin icon](https://raw2.github.com/marcinwieprzkowicz/take-screenshot/master/images/icon-19.png)
 - Wait, until new tab will open with image

--- a/javascripts/content-script.js
+++ b/javascripts/content-script.js
@@ -15,9 +15,9 @@ function getPageSettings() {
 }
 
 function setFixed(fixed) {
-	var elems = document.body.getElementsByTagName("*");
 	for (var i in fixed) {
-		elems[parseInt(i)].style.display = fixed[i];
+		var elem = document.getElementById(i);
+		elem.style.display = fixed[i];
 	}
 }
 
@@ -26,17 +26,21 @@ function getFixed() {
 	var elems = document.body.getElementsByTagName("*");
 	for (var i = 0; i < elems.length; i++) {
 		var styles = getComputedStyle(elems[i]);
-		if (styles.getPropertyValue("position") == "fixed") {
-			fixed[i] = styles.getPropertyValue("display");
+		var position = styles.getPropertyValue("position");
+		if (['fixed', 'sticky', '-webkit-sticky'].indexOf(position) > -1) {
+			if (!elems[i].id) {
+				elems[i].id = Math.random().toString();
+			}
+			fixed[elems[i].id] = styles.getPropertyValue("display");
 		}
 	}
 	return fixed;
 }
 
 function hideFixed(fixed) {
-	var elems = document.body.getElementsByTagName("*");
 	for (var i in fixed) {
-		elems[parseInt(i)].style.display = "none";
+		var elem = document.getElementById(i);
+		elem.style.display = "none";
 	}
 }
 
@@ -47,7 +51,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 			if (request.hideFixedElems) {
 				hideFixed(originalParams.fixed);
 			}
-			document.querySelector("html").style.overflow = "hidden";
+			document.querySelector("body").style.overflow = "hidden";
 			document.querySelector("html").style.scrollBehavior = "auto";
 			window.scrollTo({top:0, behavior:"auto"});
 

--- a/javascripts/content-script.js
+++ b/javascripts/content-script.js
@@ -1,51 +1,102 @@
-function resetPage(originalParams) {
-	window.scrollTo(0, originalParams.scrollTop);
+function resetPageSettings(originalParams) {
+	setFixed(originalParams.fixed);
 	document.querySelector("body").style.overflow = originalParams.overflow;
+	window.scrollTo({top:originalParams.scrollTop, behavior:"auto"});
+	document.querySelector("html").style.scrollBehavior = originalParams.scrollBehavior;
+}
+
+function getPageSettings() {
+	return {
+		"scrollTop"     : document.documentElement.scrollTop,
+		"overflow"      : getComputedStyle(document.querySelector("body")).getPropertyValue("overflow"),
+		"scrollBehavior": getComputedStyle(document.querySelector("html")).getPropertyValue("scroll-behavior"),
+		"fixed"         : getFixed()
+	};
+}
+
+function setFixed(fixed) {
+	var elems = document.body.getElementsByTagName("*");
+	for (var i in fixed) {
+		elems[parseInt(i)].style.display = fixed[i];
+	}
+}
+
+function getFixed() {
+	var fixed = {};
+	var elems = document.body.getElementsByTagName("*");
+	for (var i = 0; i < elems.length; i++) {
+		var styles = getComputedStyle(elems[i]);
+		if (styles.getPropertyValue("position") == "fixed") {
+			fixed[i] = styles.getPropertyValue("display");
+		}
+	}
+	return fixed;
+}
+
+function hideFixed(fixed) {
+	var elems = document.body.getElementsByTagName("*");
+	for (var i in fixed) {
+		elems[parseInt(i)].style.display = "none";
+	}
 }
 
 chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 	switch (request.msg) {
 		case "getPageDetails":
-			var size = {
-				width: Math.max(
-					document.documentElement.clientWidth,
-					document.body.scrollWidth,
-					document.documentElement.scrollWidth,
-					document.body.offsetWidth,
-					document.documentElement.offsetWidth
-				),
-				height: Math.max(
-					document.documentElement.clientHeight,
-					document.body.scrollHeight,
-					document.documentElement.scrollHeight,
-					document.body.offsetHeight,
-					document.documentElement.offsetHeight
-				)
-			};
+			var originalParams = getPageSettings();
+			if (request.hideFixedElems) {
+				hideFixed(originalParams.fixed);
+			}
+			document.querySelector("html").style.overflow = "hidden";
+			document.querySelector("html").style.scrollBehavior = "auto";
+			window.scrollTo({top:0, behavior:"auto"});
 
-			chrome.extension.sendMessage({
-				"msg": "setPageDetails",
-				"size": size,
-				"scrollBy": window.innerHeight,
-				"originalParams": {
-					"overflow": document.querySelector("body").style.overflow,
-					"scrollTop": document.documentElement.scrollTop
-				}
-			});
+			function setPageDetails() {
+				document.querySelector("html").style.scrollBehavior = "auto";
+				window.scrollTo({top:0, behavior:"auto"});
+
+				var size = {
+					width: Math.max(
+						document.documentElement.clientWidth,
+						document.body.scrollWidth,
+						document.documentElement.scrollWidth,
+						document.body.offsetWidth,
+						document.documentElement.offsetWidth
+					),
+					height: Math.max(
+						document.documentElement.clientHeight,
+						document.body.scrollHeight,
+						document.documentElement.scrollHeight,
+						document.body.offsetHeight,
+						document.documentElement.offsetHeight
+					)
+				};
+
+				chrome.extension.sendMessage({
+					"msg": "setPageDetails",
+					"size": size,
+					"scrollBy": window.innerHeight,
+					"originalParams": originalParams
+				});
+			}
+
+			if (request.prescrollPage) {
+				document.querySelector("html").style.scrollBehavior = "smooth";
+				window.scrollTo({top:document.body.scrollHeight, behavior:"smooth"});
+				setTimeout(setPageDetails, 5000);
+			}
+			else {
+				setPageDetails();
+			}
 			break;
 
 		case "scrollPage":
 			var lastCapture = false;
 
-			window.scrollTo(0, request.scrollTo);
-
-			// first scrolling
-			if (request.scrollTo === 0) {
-				document.querySelector("body").style.overflow = "hidden";
-			}
+			window.scrollTo({top:request.scrollTo, behavior:"auto"});
 
 			// last scrolling
-			if (request.size.height <= window.scrollY + request.scrollBy) {
+			if (request.size.height <= Math.round(window.scrollY) + request.scrollBy) {
 				lastCapture = true;
 				request.scrollTo = request.size.height - request.scrollBy;
 			}
@@ -58,7 +109,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 			break;
 
 		case "resetPage":
-			resetPage(request.originalParams);
+			resetPageSettings(request.originalParams);
 			break;
 
 		case "showError":
@@ -71,7 +122,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, callback) {
 				errorEl.firstChild.style.opacity = 0;
 			}, 3000);
 
-			resetPage(request.originalParams);
+			resetPageSettings(request.originalParams);
 			break;
 	}
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Take screenshot",
-	"version": "1.0",
+	"version": "1.1",
 	"description": "Take screenshot of the entire web page",
 	"author": "marcin.wieprzkowicz@gmail.com",
 	"icons": {
@@ -21,8 +21,9 @@
 		}
 	],
 	"permissions": [
-        "activeTab",
-		"tabs"
+		"activeTab",
+		"tabs",
+		"contextMenus"
 	],
 	"browser_action": {
 		"default_icon": {


### PR DESCRIPTION
The plugin doesn't work reliably with pages that have the new scroll-behavior=smooth option, I've fixed that by temporarily disabling it for the screenshot.

I have also added options (enabled by default) to:
- Hide fixed elements (I'd imagine everyone doing very long screenshots isn't interested in the floating menu bar)
- Pre-scroll through whole page (some ads don't fully load till they are displayed - and suddenly your screenshot turns out to be longer than calculated in the beginning)